### PR TITLE
add important note about pyyaml requirement.

### DIFF
--- a/beanstalkd.py
+++ b/beanstalkd.py
@@ -3,6 +3,8 @@
 #
 
 import collectd
+#in addition to beanstalkc, you should also install pyyaml - else beanstalkc won't return dict's to stats().
+#but it won't error or warn, because collectd's python doesnt have a logger..
 from beanstalkc import Connection
 
 class Beanstalk(object):


### PR DESCRIPTION
if there was a logger, you'd see:

```
2015-03-25 21:59:48,215 ERROR    Failed to load PyYAML, will not parse YAML
```

and then you'd get exceptions like

```
Mar 25 21:14:03 golfmobile-testing-beanstalkd-01 collectd[25452]: TypeError: string indices must be integers, not str
```

because srv_stats becomes a string instead of a dict.

oh what a fun day.
